### PR TITLE
Merge feature/IESP-215

### DIFF
--- a/src/main/java/it/pagopa/interop/probing/caller/config/thread/BlockingTaskSubmissionPolicy.java
+++ b/src/main/java/it/pagopa/interop/probing/caller/config/thread/BlockingTaskSubmissionPolicy.java
@@ -1,0 +1,13 @@
+package it.pagopa.interop.probing.caller.config.thread;
+
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class BlockingTaskSubmissionPolicy implements RejectedExecutionHandler {
+  @Override
+  public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+    if (!executor.getQueue().offer(r)) {
+      new ThreadPoolExecutor.CallerRunsPolicy();
+    }
+  }
+}

--- a/src/main/java/it/pagopa/interop/probing/caller/config/thread/ThreadConfig.java
+++ b/src/main/java/it/pagopa/interop/probing/caller/config/thread/ThreadConfig.java
@@ -1,0 +1,39 @@
+package it.pagopa.interop.probing.caller.config.thread;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class ThreadConfig implements AsyncConfigurer {
+
+  @Value("${threadpool.max-pool-size}")
+  private int maxPoolSize;
+
+  @Value("${threadpool.queue-capacity}")
+  private int queueCapacity;
+
+  @Value("${threadpool.core-pool-size}")
+  private int corePoolSize;
+
+  @Value("${threadpool.thread-name-prefix}")
+  private String threadNamePrefix;
+
+  @Override
+  @Bean(name = "threadPoolTaskExecutor")
+  public ThreadPoolTaskExecutor getAsyncExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(corePoolSize);
+    executor.setMaxPoolSize(maxPoolSize);
+    executor.setQueueCapacity(queueCapacity);
+    executor.setThreadNamePrefix(threadNamePrefix);
+    executor.setRejectedExecutionHandler(new BlockingTaskSubmissionPolicy());
+    executor.initialize();
+    return executor;
+  }
+
+}

--- a/src/main/java/it/pagopa/interop/probing/caller/util/ClientUtil.java
+++ b/src/main/java/it/pagopa/interop/probing/caller/util/ClientUtil.java
@@ -102,7 +102,7 @@ public class ClientUtil {
           .readValue(response.body().asReader(StandardCharsets.UTF_8), Problem.class);
       reason = problem.getDetail() != null && problem.getDetail().isEmpty() ? problem.getDetail()
           : String.valueOf(response.status());
-      logger.logResultCallProbing(response.status(), problem.toString(), elapsedTime);
+      logger.logResultCallProbing(response.status(), reason, elapsedTime);
     }
     return reason;
   }

--- a/src/main/java/it/pagopa/interop/probing/caller/util/logging/Logger.java
+++ b/src/main/java/it/pagopa/interop/probing/caller/util/logging/Logger.java
@@ -4,7 +4,7 @@ import it.pagopa.interop.probing.caller.dto.impl.TelemetryDto;
 
 public interface Logger {
 
-  void logMessageReceiver(Long id);
+  void logMessageReceiver(Long id, String threadId);
 
   void logMessagePushedToQueue(long eserviceRecordId, String queueLabel);
 

--- a/src/main/java/it/pagopa/interop/probing/caller/util/logging/impl/LoggerImpl.java
+++ b/src/main/java/it/pagopa/interop/probing/caller/util/logging/impl/LoggerImpl.java
@@ -12,8 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 public class LoggerImpl implements Logger {
 
   @Override
-  public void logMessageReceiver(Long id) {
-    log.info("Writing message, id={}", id);
+  public void logMessageReceiver(Long id, String threadId) {
+    log.info("Writing message, id={}. Message processed by thread {}", id, threadId);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class LoggerImpl implements Logger {
   }
 
   public void logMessagePushedToQueue(long eserviceRecordId, String queueLabel) {
-    log.info("Service with record id {} has been published in SQS {} queue: ", eserviceRecordId,
+    log.info("Service with record id {} has been published in SQS {} queue.", eserviceRecordId,
         queueLabel);
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,8 @@ jwt.payload.subject=${JWT_PAYLOAD_SUBJECT}
 jwt.payload.kid-kms=${JWT_PAYLOAD_KID_KMS}
 
 feign.client.config.default.loggerLevel = FULL
+
+ threadpool.max-pool-size=${THREADPOOL_MAX_POOL_SIZE}
+ threadpool.queue-capacity=${THREADPOOL_QUEUE_CAPACITY}
+ threadpool.core-pool-size=${THREADPOOL_CORE_POOL_SIZE}
+ threadpool.thread-name-prefix=${THREADPOOL_THREAD_NAME_PREFIX}

--- a/src/test/java/it/pagopa/interop/probing/caller/unit/producer/PollingResultSendTest.java
+++ b/src/test/java/it/pagopa/interop/probing/caller/unit/producer/PollingResultSendTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -19,20 +20,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.messaging.listener.SimpleMessageListenerContainer;
 import it.pagopa.interop.probing.caller.dto.impl.PollingDto;
 import it.pagopa.interop.probing.caller.producer.PollingResultSend;
-import it.pagopa.interop.probing.caller.util.logging.Logger;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
 class PollingResultSendTest {
 
   @InjectMocks
-  PollingResultSend pollingResultSend;
+  @Autowired
+  private PollingResultSend pollingResultSend;
 
   @Mock
   private AmazonSQSAsync amazonSQS;
-
-  @Mock
-  private Logger logger;
 
   @MockBean
   private SimpleMessageListenerContainer simpleMessageListenerContainer;

--- a/src/test/java/it/pagopa/interop/probing/caller/unit/producer/TelemetryResultSendTest.java
+++ b/src/test/java/it/pagopa/interop/probing/caller/unit/producer/TelemetryResultSendTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -19,17 +20,14 @@ import io.awspring.cloud.messaging.listener.SimpleMessageListenerContainer;
 import it.pagopa.interop.probing.caller.dto.impl.TelemetryDto;
 import it.pagopa.interop.probing.caller.producer.TelemetryResultSend;
 import it.pagopa.interop.probing.caller.util.EserviceStatus;
-import it.pagopa.interop.probing.caller.util.logging.Logger;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
 class TelemetryResultSendTest {
 
   @InjectMocks
-  TelemetryResultSend telemetryResultSend;
-
-  @Mock
-  private Logger logger;
+  @Autowired
+  private TelemetryResultSend telemetryResultSend;
 
   @Mock
   private AmazonSQSAsync amazonSQS;
@@ -38,7 +36,7 @@ class TelemetryResultSendTest {
   private SimpleMessageListenerContainer simpleMessageListenerContainer;
 
   @Mock
-  ObjectMapper mapper;
+  private ObjectMapper mapper;
 
   private TelemetryDto telemetryDto;
   private static final String TEST_URL = "http://queue/test-queue";

--- a/src/test/java/it/pagopa/interop/probing/caller/unit/util/ClientUtilTest.java
+++ b/src/test/java/it/pagopa/interop/probing/caller/unit/util/ClientUtilTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -43,16 +44,16 @@ import it.pagopa.interop.probing.caller.util.logging.Logger;
 class ClientUtilTest {
 
   @Mock
-  RestClientConfig restClientConfig;
+  private RestClientConfig restClientConfig;
 
   @Mock
-  SoapClientConfig soapClientConfig;
+  private SoapClientConfig soapClientConfig;
 
   @Mock
-  FeignRestClient feignRestClient;
+  private FeignRestClient feignRestClient;
 
   @Mock
-  FeignSoapClient feignSoapClient;
+  private FeignSoapClient feignSoapClient;
 
   @Mock
   JwtBuilder jwtBuilder;
@@ -64,7 +65,8 @@ class ClientUtilTest {
   private SimpleMessageListenerContainer simpleMessageListenerContainer;
 
   @InjectMocks
-  ClientUtil clientUtil;
+  @Autowired
+  private ClientUtil clientUtil;
 
   @Value("classpath:data/bodyContent.json")
   private Resource bodyContent;

--- a/src/test/java/it/pagopa/interop/probing/caller/unit/util/EserviceStateTest.java
+++ b/src/test/java/it/pagopa/interop/probing/caller/unit/util/EserviceStateTest.java
@@ -1,0 +1,43 @@
+package it.pagopa.interop.probing.caller.unit.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import it.pagopa.interop.probing.caller.util.EserviceStatus;
+
+class EserviceStateTest {
+  @Test
+  @DisplayName("getValue should return the correct value")
+  void testGetValue_thenReturnsCorrectValue() {
+    assertEquals("OK", EserviceStatus.OK.getValue());
+  }
+
+  @Test
+  @DisplayName("fromValue with 'OK' should return EserviceStatus.OK")
+  void testFromValue_givenValueACTIVE_thenReturnsEserviceStateACTIVE() {
+    EserviceStatus status = EserviceStatus.fromValue("OK");
+
+    assertEquals(EserviceStatus.OK, status);
+  }
+
+  @Test
+  @DisplayName("fromValue with 'KO' should return EserviceStatus.KO")
+  void testFromValue_givenValueINACTIVE_thenReturnsEserviceStatusINACTIVE() {
+    EserviceStatus status = EserviceStatus.fromValue("KO");
+
+    assertEquals(EserviceStatus.KO, status);
+  }
+
+  @Test
+  @DisplayName("fromValue with invalid value should throw an exception")
+  void testFromValue_givenInvalidValue_thenThrowException() {
+    assertThrows(IllegalArgumentException.class, () -> EserviceStatus.fromValue("SUCCESS"));
+  }
+
+  @Test
+  @DisplayName("toString should return the string representation of EserviceStatus.KO")
+  void testToString_givenValidValueKO_thenReturnsStringValue() {
+    assertEquals("KO", EserviceStatus.KO.toString());
+  }
+}

--- a/src/test/java/it/pagopa/interop/probing/caller/unit/util/EserviceStatusTest.java
+++ b/src/test/java/it/pagopa/interop/probing/caller/unit/util/EserviceStatusTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import it.pagopa.interop.probing.caller.util.EserviceStatus;
 
-class EserviceStateTest {
+class EserviceStatusTest {
   @Test
   @DisplayName("getValue should return the correct value")
   void testGetValue_thenReturnsCorrectValue() {

--- a/src/test/java/it/pagopa/interop/probing/caller/unit/util/EserviceTechnologyTest.java
+++ b/src/test/java/it/pagopa/interop/probing/caller/unit/util/EserviceTechnologyTest.java
@@ -1,0 +1,44 @@
+package it.pagopa.interop.probing.caller.unit.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import it.pagopa.interop.probing.caller.util.EserviceTechnology;
+
+class EserviceTechnologyTest {
+
+  @Test
+  @DisplayName("getValue should return the correct value")
+  void testGetValue_thenReturnsCorrectValue() {
+    assertEquals("REST", EserviceTechnology.REST.getValue());
+  }
+
+  @Test
+  @DisplayName("fromValue with 'REST' should return EserviceTechnology.REST")
+  void testFromValue_givenValueREST_thenReturnsEserviceTechnologyREST() {
+    EserviceTechnology technology = EserviceTechnology.fromValue("REST");
+
+    assertEquals(EserviceTechnology.REST, technology);
+  }
+
+  @Test
+  @DisplayName("fromValue with 'SOAP' should return EserviceTechnology.SOAP")
+  void testFromValue_givenValueSOAP_thenReturnsEserviceTechnologySOAP() {
+    EserviceTechnology technology = EserviceTechnology.fromValue("SOAP");
+
+    assertEquals(EserviceTechnology.SOAP, technology);
+  }
+
+  @Test
+  @DisplayName("fromValue with invalid value should throw an exception")
+  void testFromValue_givenInvalidValue_thenThrowException() {
+    assertThrows(IllegalArgumentException.class, () -> EserviceTechnology.fromValue("rest"));
+  }
+
+  @Test
+  @DisplayName("toString should return the string representation of EserviceTechnology.SOAP")
+  void testToString_givenValidValueSOAP_thenReturnsStringValue() {
+    assertEquals("SOAP", EserviceTechnology.SOAP.toString());
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -6,3 +6,8 @@ jwt.payload.expire-time-in-seconds=
 jwt.payload.issuer=
 jwt.payload.subject=
 jwt.payload.kid-kms=
+
+threadpool.max-pool-size=5
+threadpool.queue-capacity=5
+threadpool.core-pool-size=0
+threadpool.thread-name-prefix=AsyncThread-


### PR DESCRIPTION
ThreadPoolTaskExecutor provides a thread pool implementation for executing tasks asynchronously, pre-initialized and reusable threads that can be used to execute a set of concurrent tasks. Instead of creating a new thread each time a task is required to perform, the thread pool maintains a pool of available threads ready for execution.

The thread pool can be configured with a maximum number of threads that can be active at the same time. This helps to avoid an excessive number of threads that could overload the system.
The number of threads can be scaled based on the workload to ensure a balance between resource efficiency and performance.

I configured ThreadPoolTaskExecutor with the following properties:
- **setCorePoolSize**: set the minimum number of threads in the pool. These threads will be kept alive even when there are no tasks to perform.
- **setMaxPoolSize**: set the maximum number of threads in the pool. This represents the upper limit for the number of threads that will be created based on the workload.
- **setQueueCapacity**: set the capacity of the task queue. When all threads in the pool are busy and the queue is full, additional tasks will be handled according to the specified rejected task handling policy.
- **setThreadNamePrefix**: set the prefix of thread names created by the pool.
- **setRejectedExecutionHandler**: set the rejected task handling policy. In this case the **_CallerRunsPolicy_** was used.
With this policy, when the thread pool is full, the calling thread trying to submit a task is used to execute it directly. This is useful if the task is urgent or if you want to ensure that all tasks get done, even if at the cost of slowing down overall execution.